### PR TITLE
fix(frontend): Selection by scrolling

### DIFF
--- a/frontend/lib/modules/connections/ui/connection_card.dart
+++ b/frontend/lib/modules/connections/ui/connection_card.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:cliq/modules/connections/model/connection_full.model.dart';
 import 'package:cliq/shared/ui/context_menu.dart';
 import 'package:cliq/shared/utils/commons.dart';
+import 'package:cliq/shared/utils/platform_utils.dart';
 import 'package:cliq_term/cliq_term.dart';
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
@@ -148,7 +149,8 @@ class ConnectionCard extends HookConsumerWidget {
             children: [
               Flexible(
                 child: GestureDetector(
-                  onDoubleTap: connect,
+                  onTap: PlatformUtils.isMobile ? connect : null,
+                  onDoubleTap: PlatformUtils.isDesktop ? connect : null,
                   child: Row(
                     spacing: 16,
                     children: [

--- a/frontend/lib/modules/session/view/ssh_session_page.dart
+++ b/frontend/lib/modules/session/view/ssh_session_page.dart
@@ -7,6 +7,7 @@ import 'package:cliq/modules/settings/extension/custom_terminal_theme.extension.
 import 'package:cliq/modules/settings/model/keyboard_shortcuts.model.dart';
 import 'package:cliq/modules/settings/provider/terminal_theme.provider.dart';
 import 'package:cliq/shared/provider/store.provider.dart';
+import 'package:cliq/shared/ui/repeatable_button.dart';
 import 'package:cliq_term/cliq_term.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart' hide LicensePage;
@@ -115,7 +116,10 @@ class _SshSessionPageState extends ConsumerState<SshSessionPage>
           if (!bellSound.value) return;
           SystemSound.play(.alert);
         },
-        onTitleChange: (title) => windowManager.setTitle(title),
+        onTitleChange: (title) {
+          if (!PlatformUtils.isDesktop) return;
+          windowManager.setTitle(title);
+        },
         onHyperlinkTap: (hyperlink) {
           debugPrint('Hyperlink tapped: $hyperlink');
           // TODO: handle hyperlinks?
@@ -313,14 +317,15 @@ class _SshSessionPageState extends ConsumerState<SshSessionPage>
       String? text,
       IconData? icon,
       FButtonVariant? variant,
+      bool repeatable = false,
     }) {
       assert(
         text != null || icon != null,
         'Either text or icon must be provided',
       );
-      return FButton.icon(
+      Widget child = FButton.icon(
         variant: variant ?? .outline,
-        onPress: onPress,
+        onPress: repeatable ? () {} : onPress,
         child: text == null
             ? Icon(icon!, size: 16)
             : Text(
@@ -328,6 +333,12 @@ class _SshSessionPageState extends ConsumerState<SshSessionPage>
                 style: .new().copyWith(fontSize: 12, fontWeight: .bold),
               ),
       );
+
+      if (repeatable) {
+        child = RepeatableButton(onPress: onPress, child: child);
+      }
+
+      return child;
     }
 
     getButtonVariantForState(AccessoryBarButtonState state) {
@@ -375,18 +386,22 @@ class _SshSessionPageState extends ConsumerState<SshSessionPage>
             buildAccessoryButton(
               () => actions.sendInput(kSeqCursorUp),
               icon: LucideIcons.arrowUp,
+              repeatable: true,
             ),
             buildAccessoryButton(
               () => actions.sendInput(kSeqCursorDown),
               icon: LucideIcons.arrowDown,
+              repeatable: true,
             ),
             buildAccessoryButton(
               () => actions.sendInput(kSeqCursorLeft),
               icon: LucideIcons.arrowLeft,
+              repeatable: true,
             ),
             buildAccessoryButton(
               () => actions.sendInput(kSeqCursorRight),
               icon: LucideIcons.arrowRight,
+              repeatable: true,
             ),
           ],
           suffixItem: buildAccessoryButton(

--- a/frontend/lib/modules/session/view/ssh_session_page.dart
+++ b/frontend/lib/modules/session/view/ssh_session_page.dart
@@ -414,6 +414,14 @@ class _SshSessionPageState extends ConsumerState<SshSessionPage>
       };
     }
 
+    final rawKeyboardInset = MediaQuery.of(context).viewInsets.bottom;
+    final adjustedKeyboardInset = PlatformUtils.isMobile
+        ? (rawKeyboardInset - kBottomNavigationBarHeight).clamp(
+            0.0,
+            double.infinity,
+          )
+        : rawKeyboardInset;
+
     return GenericSessionPage(
       session: session,
       isConnected: session.isConnected && terminalController.value != null,
@@ -425,7 +433,7 @@ class _SshSessionPageState extends ConsumerState<SshSessionPage>
           padding: kShellSessionPagePadding.copyWith(
             bottom:
                 kShellSessionPagePadding.bottom +
-                MediaQuery.of(context).viewInsets.bottom +
+                adjustedKeyboardInset +
                 TerminalView.getAccessoryBarHeight(PlatformUtils.isMobile),
           ),
           child: TerminalView(

--- a/frontend/lib/shared/ui/navigation/navigation_shell.dart
+++ b/frontend/lib/shared/ui/navigation/navigation_shell.dart
@@ -408,13 +408,14 @@ class NavigationShellState extends ConsumerState<NavigationShell>
           bottom: false,
           child: Stack(
             children: [
-              Positioned.fill(
-                child: GestureDetector(
-                  behavior: HitTestBehavior.opaque,
-                  onDoubleTap: () async => await toggleMaximize(),
-                  onPanStart: (_) => windowManager.startDragging(),
+              if (PlatformUtils.isDesktop)
+                Positioned.fill(
+                  child: GestureDetector(
+                    behavior: HitTestBehavior.opaque,
+                    onDoubleTap: () async => await toggleMaximize(),
+                    onPanStart: (_) => windowManager.startDragging(),
+                  ),
                 ),
-              ),
 
               Padding(
                 padding:

--- a/frontend/lib/shared/ui/repeatable_button.dart
+++ b/frontend/lib/shared/ui/repeatable_button.dart
@@ -53,13 +53,14 @@ class _RepeatableButtonState extends State<RepeatableButton> {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTapDown: (_) {
-        widget.onPress(); // immediate feedback on first press
+    return Listener(
+      behavior: HitTestBehavior.opaque,
+      onPointerDown: (_) {
+        widget.onPress();
         _start();
       },
-      onTapUp: (_) => _stop(),
-      onTapCancel: () => _stop(),
+      onPointerUp: (_) => _stop(),
+      onPointerCancel: (_) => _stop(),
       child: widget.child,
     );
   }

--- a/frontend/lib/shared/ui/repeatable_button.dart
+++ b/frontend/lib/shared/ui/repeatable_button.dart
@@ -1,0 +1,66 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+
+class RepeatableButton extends StatefulWidget {
+  /// The [onPress] callback is called immediately when the button is pressed.
+  final VoidCallback onPress;
+
+  /// The [child] widget is displayed inside the button.
+  final Widget child;
+
+  /// The [initialDelay] is the duration to wait before starting to repeat the [onPress] callback.
+  final Duration initialDelay;
+
+  /// The [repeatInterval] is the duration between each repeated call to the [onPress] callback.
+  final Duration repeatInterval;
+
+  const RepeatableButton({
+    super.key,
+    required this.onPress,
+    required this.child,
+    this.initialDelay = const .new(milliseconds: 400),
+    this.repeatInterval = const .new(milliseconds: 80),
+  });
+
+  @override
+  State<RepeatableButton> createState() => _RepeatableButtonState();
+}
+
+class _RepeatableButtonState extends State<RepeatableButton> {
+  Timer? _initialTimer;
+  Timer? _repeatTimer;
+
+  void _start() {
+    _initialTimer = Timer(widget.initialDelay, () {
+      _repeatTimer = Timer.periodic(widget.repeatInterval, (_) {
+        widget.onPress();
+      });
+    });
+  }
+
+  void _stop() {
+    _initialTimer?.cancel();
+    _repeatTimer?.cancel();
+    _initialTimer = null;
+    _repeatTimer = null;
+  }
+
+  @override
+  void dispose() {
+    _stop();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTapDown: (_) {
+        widget.onPress(); // immediate feedback on first press
+        _start();
+      },
+      onTapUp: (_) => _stop(),
+      onTapCancel: () => _stop(),
+      child: widget.child,
+    );
+  }
+}

--- a/frontend/packages/cliq_term/lib/src/widgets/terminal_view.dart
+++ b/frontend/packages/cliq_term/lib/src/widgets/terminal_view.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:cliq_term/cliq_term.dart';
 import 'package:cliq_term/src/parser/escape_emitter.dart';
 import 'package:cliq_term/src/utils/keyboard_helper.dart';
@@ -278,6 +276,35 @@ class _TerminalViewState extends State<TerminalView> {
           );
         }
 
+        dispatchPanScroll(
+          double dy,
+          double cellH,
+          Offset localPosition,
+          (int, int) Function(Offset) coordsFor,
+        ) {
+          if (!widget.controller.backBufferActive &&
+              widget.controller.mouseTrackingMode == .none) {
+            return false;
+          }
+          if (dy == 0) return false;
+
+          _panScrollAccumulator += dy * _panScrollSensitivity;
+
+          final lines = (_panScrollAccumulator.abs() / cellH).floor();
+          if (lines <= 0) return true;
+
+          _panScrollAccumulator -= lines * cellH * _panScrollAccumulator.sign;
+
+          final (row, col) = coordsFor(localPosition);
+          widget.controller.handleScroll(
+            row: row,
+            col: col,
+            up: dy > 0,
+            lines: lines,
+          );
+          return true;
+        }
+
         return TerminalInput(
           focusNode: _focusNode,
           readOnly: widget.readOnly,
@@ -285,9 +312,12 @@ class _TerminalViewState extends State<TerminalView> {
           onFocusChange: (hasFocus) {
             if (hasFocus) {
               _showAccessoryBar();
+              _keyboardVisible.value = true;
               widget.controller.startCursorBlink();
             } else {
               widget.controller.stopCursorBlink();
+              _accessoryBarEntry?.remove();
+              _accessoryBarEntry = null;
             }
 
             if (widget.controller.focusReportingEnabled) {
@@ -342,30 +372,15 @@ class _TerminalViewState extends State<TerminalView> {
                 button: button,
               );
             },
+            onPointerPanZoomStart: (event) {
+              _panScrollAccumulator = 0;
+            },
             onPointerPanZoomUpdate: (event) {
-              if (!widget.controller.backBufferActive &&
-                  widget.controller.mouseTrackingMode == .none) {
-                return;
-              }
-
-              final dy = event.panDelta.dy;
-              if (dy == 0) return;
-
-              _panScrollAccumulator += dy * _panScrollSensitivity;
-
-              final lines = (_panScrollAccumulator.abs() / cellH).floor();
-              if (lines <= 0) return;
-
-              // consume only the whole lines we're about to send, keep leftover fraction
-              _panScrollAccumulator -=
-                  lines * cellH * _panScrollAccumulator.sign;
-
-              final (row, col) = coordsFor(event.localPosition);
-              widget.controller.handleScroll(
-                row: row,
-                col: col,
-                up: dy > 0,
-                lines: lines,
+              dispatchPanScroll(
+                event.panDelta.dy,
+                cellH,
+                event.localPosition,
+                coordsFor,
               );
             },
             onPointerPanZoomEnd: (event) {
@@ -382,13 +397,31 @@ class _TerminalViewState extends State<TerminalView> {
               );
             },
             onPointerMove: (event) {
-              if (!_mouseReportingActive) return;
-              final (row, col) = coordsFor(event.localPosition);
-              widget.controller.reportMouseEvent(
-                row: row,
-                col: col,
-                isMotion: true,
-              );
+              // Touch-drag scroll on mobile takes priority over raw motion
+              // reporting: a vertical drag should scroll (translated to
+              // wheel events or arrow keys by handleScroll) even when the
+              // program has mouse tracking enabled for other purposes
+              // (e.g. btop's clickable process list) — matching how
+              // desktop trackpad/wheel scrolling already behaves
+              // regardless of mouse-tracking state.
+              if (!widget.allowTextSelection) {
+                dispatchPanScroll(
+                  event.delta.dy,
+                  cellH,
+                  event.localPosition,
+                  coordsFor,
+                );
+                return;
+              }
+
+              if (_mouseReportingActive) {
+                final (row, col) = coordsFor(event.localPosition);
+                widget.controller.reportMouseEvent(
+                  row: row,
+                  col: col,
+                  isMotion: true,
+                );
+              }
             },
             onPointerSignal: (event) {
               if (event is! PointerScrollEvent) return;
@@ -429,37 +462,23 @@ class _TerminalViewState extends State<TerminalView> {
               },
               onPanStart: (details) {
                 _focusNode.requestFocus();
+                _panScrollAccumulator = 0;
                 if (!widget.allowTextSelection || _mouseReportingActive) return;
-                final (
-                  absRow,
-                  absCol,
-                ) = GestureSelectionHandler.calculateAbsoluteCoordinates(
-                  localPosition: details.localPosition,
-                  scrollOffset: _scrollController.hasClients
-                      ? _scrollController.offset
-                      : 0.0,
-                  cellWidth: cellW,
-                  cellHeight: cellH,
-                  totalRows: totalRows,
-                  maxCols: widget.controller.cols,
-                );
+                final (absRow, absCol) = coordsFor(details.localPosition);
                 widget.controller.startSelection(absRow, absCol);
               },
               onPanUpdate: (details) {
-                if (!widget.allowTextSelection || _mouseReportingActive) return;
-                final (
-                  absRow,
-                  absCol,
-                ) = GestureSelectionHandler.calculateAbsoluteCoordinates(
-                  localPosition: details.localPosition,
-                  scrollOffset: _scrollController.hasClients
-                      ? _scrollController.offset
-                      : 0.0,
-                  cellWidth: cellW,
-                  cellHeight: cellH,
-                  totalRows: totalRows,
-                  maxCols: widget.controller.cols,
-                );
+                if (!widget.allowTextSelection) {
+                  dispatchPanScroll(
+                    details.delta.dy,
+                    cellH,
+                    details.localPosition,
+                    coordsFor,
+                  );
+                  return;
+                }
+                if (_mouseReportingActive) return;
+                final (absRow, absCol) = coordsFor(details.localPosition);
                 widget.controller.updateSelection(absRow, absCol);
               },
               child: Container(
@@ -469,6 +488,7 @@ class _TerminalViewState extends State<TerminalView> {
                   controller: _scrollController,
                   itemCount: totalRows,
                   itemExtent: cellH,
+                  padding: .zero,
                   physics: const AlwaysScrollableScrollPhysics(
                     parent: ClampingScrollPhysics(),
                   ),

--- a/frontend/packages/cliq_term/lib/src/widgets/terminal_view.dart
+++ b/frontend/packages/cliq_term/lib/src/widgets/terminal_view.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:cliq_term/cliq_term.dart';
 import 'package:cliq_term/src/parser/escape_emitter.dart';
 import 'package:cliq_term/src/utils/keyboard_helper.dart';
@@ -9,6 +7,8 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
+
+import '../utils/gesture_selection_handler.dart';
 
 class TerminalView extends StatefulWidget {
   /// The [TerminalController] used to manage the terminal state and handle input/output.
@@ -314,10 +314,18 @@ class _TerminalViewState extends State<TerminalView> {
               _focusNode.requestFocus();
               final button = _mouseButtonFromEvent(event.buttons);
               if (button == null) return;
-              final (row, col) = _calculateCoords(
-                event.localPosition,
-                cellW,
-                cellH,
+              final (
+                row,
+                col,
+              ) = GestureSelectionHandler.calculateAbsoluteCoordinates(
+                localPosition: event.localPosition,
+                scrollOffset: _scrollController.hasClients
+                    ? _scrollController.offset
+                    : 0.0,
+                cellWidth: cellW,
+                cellHeight: cellH,
+                totalRows: totalRows,
+                maxCols: widget.controller.cols,
               );
               widget.controller.reportMouseEvent(
                 row: row,
@@ -328,10 +336,18 @@ class _TerminalViewState extends State<TerminalView> {
             onPointerUp: (event) {
               if (!_mouseReportingActive) return;
               _focusNode.requestFocus();
-              final (row, col) = _calculateCoords(
-                event.localPosition,
-                cellW,
-                cellH,
+              final (
+                row,
+                col,
+              ) = GestureSelectionHandler.calculateAbsoluteCoordinates(
+                localPosition: event.localPosition,
+                scrollOffset: _scrollController.hasClients
+                    ? _scrollController.offset
+                    : 0.0,
+                cellWidth: cellW,
+                cellHeight: cellH,
+                totalRows: totalRows,
+                maxCols: widget.controller.cols,
               );
               widget.controller.reportMouseEvent(
                 row: row,
@@ -341,10 +357,18 @@ class _TerminalViewState extends State<TerminalView> {
             },
             onPointerMove: (event) {
               if (!_mouseReportingActive) return;
-              final (row, col) = _calculateCoords(
-                event.localPosition,
-                cellW,
-                cellH,
+              final (
+                row,
+                col,
+              ) = GestureSelectionHandler.calculateAbsoluteCoordinates(
+                localPosition: event.localPosition,
+                scrollOffset: _scrollController.hasClients
+                    ? _scrollController.offset
+                    : 0.0,
+                cellWidth: cellW,
+                cellHeight: cellH,
+                totalRows: totalRows,
+                maxCols: widget.controller.cols,
               );
               widget.controller.reportMouseEvent(
                 row: row,
@@ -354,10 +378,18 @@ class _TerminalViewState extends State<TerminalView> {
             },
             onPointerSignal: (event) {
               if (event is! PointerScrollEvent) return;
-              final (row, col) = _calculateCoords(
-                event.localPosition,
-                cellW,
-                cellH,
+              final (
+                row,
+                col,
+              ) = GestureSelectionHandler.calculateAbsoluteCoordinates(
+                localPosition: event.localPosition,
+                scrollOffset: _scrollController.hasClients
+                    ? _scrollController.offset
+                    : 0.0,
+                cellWidth: cellW,
+                cellHeight: cellH,
+                totalRows: totalRows,
+                maxCols: widget.controller.cols,
               );
               widget.controller.handleScroll(
                 row: row,
@@ -375,10 +407,18 @@ class _TerminalViewState extends State<TerminalView> {
               },
               onTapUp: (details) {
                 if (_mouseReportingActive) return;
-                final (row, col) = _calculateCoords(
-                  details.localPosition,
-                  cellW,
-                  cellH,
+                final (
+                  row,
+                  col,
+                ) = GestureSelectionHandler.calculateAbsoluteCoordinates(
+                  localPosition: details.localPosition,
+                  scrollOffset: _scrollController.hasClients
+                      ? _scrollController.offset
+                      : 0.0,
+                  cellWidth: cellW,
+                  cellHeight: cellH,
+                  totalRows: totalRows,
+                  maxCols: widget.controller.cols,
                 );
                 final url = widget.controller.hyperlinkAt(row, col);
                 if (url != null) {
@@ -388,19 +428,35 @@ class _TerminalViewState extends State<TerminalView> {
               onPanStart: (details) {
                 _focusNode.requestFocus();
                 if (!widget.allowTextSelection || _mouseReportingActive) return;
-                final (absRow, absCol) = _calculateCoords(
-                  details.localPosition,
-                  cellW,
-                  cellH,
+                final (
+                  absRow,
+                  absCol,
+                ) = GestureSelectionHandler.calculateAbsoluteCoordinates(
+                  localPosition: details.localPosition,
+                  scrollOffset: _scrollController.hasClients
+                      ? _scrollController.offset
+                      : 0.0,
+                  cellWidth: cellW,
+                  cellHeight: cellH,
+                  totalRows: totalRows,
+                  maxCols: widget.controller.cols,
                 );
                 widget.controller.startSelection(absRow, absCol);
               },
               onPanUpdate: (details) {
                 if (!widget.allowTextSelection || _mouseReportingActive) return;
-                final (absRow, absCol) = _calculateCoords(
-                  details.localPosition,
-                  cellW,
-                  cellH,
+                final (
+                  absRow,
+                  absCol,
+                ) = GestureSelectionHandler.calculateAbsoluteCoordinates(
+                  localPosition: details.localPosition,
+                  scrollOffset: _scrollController.hasClients
+                      ? _scrollController.offset
+                      : 0.0,
+                  cellWidth: cellW,
+                  cellHeight: cellH,
+                  totalRows: totalRows,
+                  maxCols: widget.controller.cols,
                 );
                 widget.controller.updateSelection(absRow, absCol);
               },
@@ -411,7 +467,9 @@ class _TerminalViewState extends State<TerminalView> {
                   controller: _scrollController,
                   itemCount: totalRows,
                   itemExtent: cellH,
-                  physics: const ClampingScrollPhysics(),
+                  physics: const AlwaysScrollableScrollPhysics(
+                    parent: ClampingScrollPhysics(),
+                  ),
                   itemBuilder: (context, index) {
                     return TerminalRowWidget(
                       controller: widget.controller,
@@ -427,25 +485,6 @@ class _TerminalViewState extends State<TerminalView> {
           ),
         );
       },
-    );
-  }
-
-  (int, int) _calculateCoords(
-    Offset localPosition,
-    double cellW,
-    double cellH,
-  ) {
-    final scrollOffset = _scrollController.hasClients
-        ? _scrollController.offset
-        : 0.0;
-    final totalLocalY = localPosition.dy + scrollOffset;
-
-    final absRow = (totalLocalY / cellH).floor();
-    final col = (localPosition.dx / cellW).floor();
-
-    return (
-      absRow.clamp(0, max(0, widget.controller.totalRows - 1)),
-      col.clamp(0, widget.controller.cols - 1),
     );
   }
 }

--- a/frontend/packages/cliq_term/lib/src/widgets/terminal_view.dart
+++ b/frontend/packages/cliq_term/lib/src/widgets/terminal_view.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:cliq_term/cliq_term.dart';
 import 'package:cliq_term/src/parser/escape_emitter.dart';
 import 'package:cliq_term/src/utils/keyboard_helper.dart';
@@ -65,8 +67,14 @@ class TerminalView extends StatefulWidget {
 }
 
 class _TerminalViewState extends State<TerminalView> {
+  /// Multiplier applied to raw pan distance before converting to lines
+  static const double _panScrollSensitivity = 2.5;
+
   /// The [OverlayEntry] for the accessory bar, which is displayed above the keyboard when it is visible.
   OverlayEntry? _accessoryBarEntry;
+
+  /// The accumulated scroll delta for pan gestures.
+  double _panScrollAccumulator = 0;
 
   /// The effective [FocusNode] used for managing focus in the terminal view.
   late final FocusNode _focusNode;
@@ -257,6 +265,19 @@ class _TerminalViewState extends State<TerminalView> {
 
         final totalRows = widget.controller.totalRows;
 
+        coordsFor(Offset localPosition) {
+          return GestureSelectionHandler.calculateAbsoluteCoordinates(
+            localPosition: localPosition,
+            scrollOffset: _scrollController.hasClients
+                ? _scrollController.offset
+                : 0.0,
+            cellWidth: cellW,
+            cellHeight: cellH,
+            totalRows: totalRows,
+            maxCols: widget.controller.cols,
+          );
+        }
+
         return TerminalInput(
           focusNode: _focusNode,
           readOnly: widget.readOnly,
@@ -314,41 +335,46 @@ class _TerminalViewState extends State<TerminalView> {
               _focusNode.requestFocus();
               final button = _mouseButtonFromEvent(event.buttons);
               if (button == null) return;
-              final (
-                row,
-                col,
-              ) = GestureSelectionHandler.calculateAbsoluteCoordinates(
-                localPosition: event.localPosition,
-                scrollOffset: _scrollController.hasClients
-                    ? _scrollController.offset
-                    : 0.0,
-                cellWidth: cellW,
-                cellHeight: cellH,
-                totalRows: totalRows,
-                maxCols: widget.controller.cols,
-              );
+              final (row, col) = coordsFor(event.localPosition);
               widget.controller.reportMouseEvent(
                 row: row,
                 col: col,
                 button: button,
               );
             },
+            onPointerPanZoomUpdate: (event) {
+              if (!widget.controller.backBufferActive &&
+                  widget.controller.mouseTrackingMode == .none) {
+                return;
+              }
+
+              final dy = event.panDelta.dy;
+              if (dy == 0) return;
+
+              _panScrollAccumulator += dy * _panScrollSensitivity;
+
+              final lines = (_panScrollAccumulator.abs() / cellH).floor();
+              if (lines <= 0) return;
+
+              // consume only the whole lines we're about to send, keep leftover fraction
+              _panScrollAccumulator -=
+                  lines * cellH * _panScrollAccumulator.sign;
+
+              final (row, col) = coordsFor(event.localPosition);
+              widget.controller.handleScroll(
+                row: row,
+                col: col,
+                up: dy > 0,
+                lines: lines,
+              );
+            },
+            onPointerPanZoomEnd: (event) {
+              _panScrollAccumulator = 0;
+            },
             onPointerUp: (event) {
               if (!_mouseReportingActive) return;
               _focusNode.requestFocus();
-              final (
-                row,
-                col,
-              ) = GestureSelectionHandler.calculateAbsoluteCoordinates(
-                localPosition: event.localPosition,
-                scrollOffset: _scrollController.hasClients
-                    ? _scrollController.offset
-                    : 0.0,
-                cellWidth: cellW,
-                cellHeight: cellH,
-                totalRows: totalRows,
-                maxCols: widget.controller.cols,
-              );
+              final (row, col) = coordsFor(event.localPosition);
               widget.controller.reportMouseEvent(
                 row: row,
                 col: col,
@@ -357,19 +383,7 @@ class _TerminalViewState extends State<TerminalView> {
             },
             onPointerMove: (event) {
               if (!_mouseReportingActive) return;
-              final (
-                row,
-                col,
-              ) = GestureSelectionHandler.calculateAbsoluteCoordinates(
-                localPosition: event.localPosition,
-                scrollOffset: _scrollController.hasClients
-                    ? _scrollController.offset
-                    : 0.0,
-                cellWidth: cellW,
-                cellHeight: cellH,
-                totalRows: totalRows,
-                maxCols: widget.controller.cols,
-              );
+              final (row, col) = coordsFor(event.localPosition);
               widget.controller.reportMouseEvent(
                 row: row,
                 col: col,
@@ -378,19 +392,7 @@ class _TerminalViewState extends State<TerminalView> {
             },
             onPointerSignal: (event) {
               if (event is! PointerScrollEvent) return;
-              final (
-                row,
-                col,
-              ) = GestureSelectionHandler.calculateAbsoluteCoordinates(
-                localPosition: event.localPosition,
-                scrollOffset: _scrollController.hasClients
-                    ? _scrollController.offset
-                    : 0.0,
-                cellWidth: cellW,
-                cellHeight: cellH,
-                totalRows: totalRows,
-                maxCols: widget.controller.cols,
-              );
+              final (row, col) = coordsFor(event.localPosition);
               widget.controller.handleScroll(
                 row: row,
                 col: col,


### PR DESCRIPTION
Fixed a bug when you scrolled with two fingers on the touchpad you would actually select cells when the terminal buffer was too small to scroll.

- use gesture handler & remove code duplication