### PR TITLE
fix(cliq_term): Fix isAutoWrapMode being false by default

### DIFF
--- a/frontend/packages/cliq_term/lib/src/model/terminal_buffer.model.dart
+++ b/frontend/packages/cliq_term/lib/src/model/terminal_buffer.model.dart
@@ -76,7 +76,7 @@ class TerminalBuffer {
   bool isLineFeedMode = false;
   bool isInsertMode = false;
 
-  bool isAutoWrapMode = false;
+  bool isAutoWrapMode = true;
 
   /// Indicates whether the next character to be written should wrap to the next line
   /// and trigger an index operation


### PR DESCRIPTION
This PR fixes the `isAutoWrapMode` by setting the default state to be enabled. 
This fixes instances where text would not wrap on narrow terminal views
